### PR TITLE
Clarify version in StateHostFirmware and StateWifiFirmware

### DIFF
--- a/messages/device.md
+++ b/messages/device.md
@@ -191,7 +191,9 @@ Response to [GetHostFirmware](#gethostfirmware---14) message.
 Provides host firmware information.
 
 * build: firmware build [time](#time) (absolute time in nanoseconds since epoch)
-* version: firmware version
+* version: firmware version that consists of the major (upper 16 bits) and minor
+  (lower 16 bits) versions
+
 
 | Field | Type |
 |-------|------|
@@ -236,7 +238,8 @@ Response to [GetWifiFirmware](#getwififirmware---18) message.
 Provides Wifi subsystem information.
 
 * build: firmware build [time](#time) (absolute time in nanoseconds since epoch)
-* version: firmware version
+* version: firmware version that consists of the major (upper 16 bits) and minor
+  (lower 16 bits) versions
 
 | Field | Type |
 |-------|------|


### PR DESCRIPTION
Currently, it just says that `version` is a 32 bit integers while it actually consists of the major and minor versions.
